### PR TITLE
Add --with-ids option

### DIFF
--- a/scripts/pontoon-image
+++ b/scripts/pontoon-image
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
 """Usage:
-          pontoon image list
+          pontoon image list [--with-ids]
           pontoon image oses
           pontoon image show <name>
 
 Options:
+    --with-ids      Include ids in output. Useful for other software that uses
+                    Digital Ocean ids for input (like Packer).
     -h --help       Show this page.
 """
 
@@ -20,7 +22,10 @@ class ImageCommand(Command):
         available = self.pontoon.image.list()
         ui.message("Available images:")
         for s in available:
-            ui.message(" - %s" % s.name)
+            if self.args['--with-ids']:
+                ui.message(" - %-10s %s" % (str(s.id) + ':', s.name))
+            else:
+                ui.message(" - %s" % s.name)
         return 0
 
     def show(self):

--- a/scripts/pontoon-region
+++ b/scripts/pontoon-region
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
-"""Usage: pontoon region list [--help]
+"""Usage: pontoon region list [--with-ids]
 
 Options:
+    --with-ids      Include ids in output. Useful for other software that uses
+                    Digital Ocean ids for input (like Packer).
     -h --help       Show this page.
 """
 
@@ -17,7 +19,10 @@ class RegionCommand(Command):
         available = self.pontoon.region.list()
         ui.message("Available regions:")
         for r in available:
-            ui.message(" - %s" % r.name)
+            if self.args['--with-ids']:
+                ui.message(" - %-10s %s" % (str(r.id) + ':', r.name))
+            else:
+                ui.message(" - %s" % r.name)
         return 0
 
 

--- a/scripts/pontoon-size
+++ b/scripts/pontoon-size
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
-"""Usage: pontoon size list [--help]
+"""Usage: pontoon size list [--with-ids]
 
 Options:
+    --with-ids      Include ids in output. Useful for other software that uses
+                    Digital Ocean ids for input (like Packer).
     -h --help       Show this page.
 """
 
@@ -17,7 +19,10 @@ class SizeCommand(Command):
         available = self.pontoon.size.list()
         ui.message("Available sizes:")
         for s in available:
-            ui.message(" - %s" % s.name)
+            if self.args['--with-ids']:
+                ui.message(" - %-10s %s" % (str(s.id) + ':', s.name))
+            else:
+                ui.message(" - %s" % s.name)
         return 0
 
 

--- a/scripts/pontoon-snapshot
+++ b/scripts/pontoon-snapshot
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 
 """Usage:
-          pontoon snapshot list [--help]
+          pontoon snapshot list [--with-ids]
           pontoon snapshot show <name>
           pontoon snapshot destroy <name>
           pontoon snapshot transfer <name> <region>
 
 Options:
+    --with-ids      Include ids in output. Useful for other software that uses
+                    Digital Ocean ids for input (like Packer).
     -h --help       Show this page.
 """
 
@@ -21,7 +23,10 @@ class SnapshotCommand(Command):
         available = self.pontoon.snapshot.list()
         ui.message("Available snapshots:")
         for s in available:
-            ui.message(" - %s" % s.name)
+            if self.args['--with-ids']:
+                ui.message(" - %-10s %s" % (str(s.id) + ':', s.name))
+            else:
+                ui.message(" - %s" % s.name)
         return 0
 
     def show(self):


### PR DESCRIPTION
`--with-ids` can be specified on listing of images, regions, sizes and snapshots.
This is a convenience for tools like Packer, which use these IDs.

This will be in the next release, but if you want to use it in the mean time, install pontoon from master like so:

```
pip install git+git://github.com/duggan/pontoon.git#egg=pontoon
```
