### PR TITLE
os.getuid in try-except + sys_cfg always made empty on windows

### DIFF
--- a/pontoon/configure.py
+++ b/pontoon/configure.py
@@ -4,7 +4,12 @@ import os
 import logging
 import sys
 from os.path import expanduser
-from os import getuid
+
+try:
+    from os import getuid
+except ImportError:
+    pass
+
 from subprocess import call, Popen, PIPE, CalledProcessError
 from . import debug
 from .pontoon import Pontoon

--- a/pontoon/configure.py
+++ b/pontoon/configure.py
@@ -8,7 +8,7 @@ from os.path import expanduser
 try:
     from os import getuid
 except ImportError:
-    pass
+    getuid = None
 
 from subprocess import call, Popen, PIPE, CalledProcessError
 from . import debug

--- a/pontoon/configure.py
+++ b/pontoon/configure.py
@@ -2,6 +2,7 @@
 
 import os
 import logging
+import sys
 from os.path import expanduser
 from os import getuid
 from subprocess import call, Popen, PIPE, CalledProcessError
@@ -10,7 +11,12 @@ from .pontoon import Pontoon
 from .exceptions import SSHKeyException, ConfigureException
 
 user_cfg = os.path.join(os.path.expanduser('~'), '.pontoon')
-sys_cfg = '/etc/pontoon.conf'
+
+if sys.platform != "win32":
+    sys_cfg = '/etc/pontoon.conf'
+else:
+    sys_cfg = ""
+
 local_cfg = os.path.join(os.getcwd(), '.pontoon')
 debug_mode = True if os.environ.get("DEBUG") else False
 mock_mode = True if os.environ.get("MOCK") else False
@@ -150,8 +156,12 @@ def create_config(data):
     """Create a YAML config file from a dictionary"""
     import yaml
     data = yaml.dump(data, default_flow_style=False)
-    if getuid() == 0:  # root
-        loc = sys_cfg
+
+    if sys.platform != "win32":
+        if getuid() == 0:  # root
+            loc = sys_cfg
+        else:
+            loc = user_cfg
     else:
         loc = user_cfg
 
@@ -164,7 +174,9 @@ def read_config():
     """Read a YAML formatted config into a dictionary"""
     import yaml
     config = config_format
-    for loc in local_cfg, user_cfg, sys_cfg:
+
+    # sys_cfg empty in windows, but shouldnt affect this
+    for loc in [local_cfg, user_cfg, sys_cfg]:
         try:
             with open(loc) as source:
                 raw_config = source.read()


### PR DESCRIPTION
I dont think there is much of a concept of separate systemconfig and userconfig based on root access on Windows. I might be wrong though. Also os.getuid not supported on windows. So, to support Windows, sys_cfg is set to empty string and os.getuid is error handled.

I am not sure if there is a better solution to this, but this seems to work - atleast temporarily.