### PR TITLE
Ignore build and dist folders created by pip install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ docs/_build
 *.swp
 *.bak
 pontoon.egg-info
+build/
+dist/


### PR DESCRIPTION
Nothing too big, but helps in live pip install environments.