### PR TITLE
Empty sshkey bugfix

### DIFF
--- a/pontoon/droplet.py
+++ b/pontoon/droplet.py
@@ -10,6 +10,7 @@ from .sshkey import SSHKey
 
 
 class Droplet:
+
     """Manage operations related to Droplets."""
 
     def __init__(self, render):
@@ -89,6 +90,11 @@ class Droplet:
         if name in [d.name for d in self.list()]:
             raise DropletException(
                 'This would create two droplets with the same hostname.')
+
+        # keys should be a empty list, instead of None if nothing is passed
+        # as later it is iterated upon, without this error is raised.
+        if keys is None:
+            keys = []
 
         size_id = self.size.id_from_name(size)
         image_id = self.image.id_from_name(image)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -85,6 +85,13 @@ class TestDroplet(object):
         for server in self.droplet.list():
             assert isinstance(server, Struct)
 
+    def test_empty_ssh_keys(self):
+        ''' No keys will be passed in, shouldnt raise any error. '''
+
+        _request.side_effect = _respond
+
+        assert(isinstance(self.droplet.create(name="abcd", size="512MB", image="Foobuntu 12.04 x64", region="Foo York 2"), Struct))
+
     def test_id_from_name(self):
         _request.side_effect = _respond
 


### PR DESCRIPTION
If no ssh keyname is passed during droplet creation, error raised as it tries to iterate through a None object. So, converted it to empty list if None.
Failing test case + Fix done