### PR TITLE
Migrate to tox for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ sudo: false # use Travis container based infrastructure
 language: python
 
 env:
-  - MOCK=1 TOXENV=py26
-  - MOCK=1 TOXENV=py27
-  - MOCK=1 TOXENV=py33
-  - MOCK=1 TOXENV=py34
-  - MOCK=1 TOXENV=pypy
-  - MOCK=1 TOXENV=pypy3
+  - MOCK=1 TOXENV=py26,coveralls
+  - MOCK=1 TOXENV=py27,coveralls
+  - MOCK=1 TOXENV=py33,coveralls
+  - MOCK=1 TOXENV=py34,coveralls
+  - MOCK=1 TOXENV=pypy,coveralls
+  - MOCK=1 TOXENV=pypy3,coveralls
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,28 @@
+sudo: false # use Travis container based infrastructure
+
 language: python
-python:
-  - 2.6
-  - 2.7
-  - 3.2
-  - 3.3
-  - pypy
+
 env:
-  - MOCK=1
-before_install:
-  - sudo add-apt-repository ppa:duggan/bats --yes
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq bats
+  - MOCK=1 TOXENV=py26
+  - MOCK=1 TOXENV=py27
+  - MOCK=1 TOXENV=py32
+  - MOCK=1 TOXENV=py33
+  - MOCK=1 TOXENV=py34
+  - MOCK=1 TOXENV=pypy
+  - MOCK=1 TOXENV=pypy3
+
 install:
-  - pip install -r requirements.txt --use-mirrors
-  - pip install coveralls --use-mirrors
-  - python setup.py install
+  - pip install tox
+
+before_script:
+  - git clone https://github.com/sstephenson/bats.git /tmp/bats
+  - mkdir -p /tmp/local
+  - bash /tmp/bats/install.sh /tmp/local
+  - export PATH=$PATH:/tmp/local/bin
+
 script:
-  - bats test/bats
-  - py.test --pep8 pontoon
-  - py.test --cov=pontoon
-  - coverage report -m
-after_success:
-  - coveralls
+  - tox
+
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: python
 env:
   - MOCK=1 TOXENV=py26
   - MOCK=1 TOXENV=py27
-  - MOCK=1 TOXENV=py32
   - MOCK=1 TOXENV=py33
   - MOCK=1 TOXENV=py34
   - MOCK=1 TOXENV=pypy

--- a/pontoon/mocking.py
+++ b/pontoon/mocking.py
@@ -210,7 +210,7 @@ def _respond(target, method='GET', params={}):
                 'locked': False,
                 'created_at': timestamp(),
                 'private_ip_address': None
-                }
+            }
             mocked['droplets'].append(new)
 
             return {'droplet': new}
@@ -220,7 +220,7 @@ def _respond(target, method='GET', params={}):
                 'id': randrange(100, 999),
                 'name': params['name'],
                 'ssh_pub_key': params['ssh_pub_key']
-                }
+            }
             mocked['ssh_keys'].append(new)
 
             return {'ssh_key': new}

--- a/pontoon/ui.py
+++ b/pontoon/ui.py
@@ -149,10 +149,10 @@ def box(text, decor='*', decor_x=None, decor_y=None,
     text = "\n".join([
         "{decor_y}{text}{decor_y}".format(
             decor_y=decor_y, text=m.center(
-                boxwidth-decor_y_multiplier)) for m in text])
+                boxwidth - decor_y_multiplier)) for m in text])
     border_x = (decor_x * decor_x_multiplier)
     border_space = "{decor_y}{spacer}{decor_y}".format(
-        decor_y=decor_y, spacer=(" " * (boxwidth-decor_y_multiplier)))
+        decor_y=decor_y, spacer=(" " * (boxwidth - decor_y_multiplier)))
     spacing = (' ' * boxwidth)
     text = "\n".join([
         spacing, border_x, border_space, text,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,3 @@ PyYAML
 docopt
 requests
 mock
-pytest
-pytest-cov
-pytest-pep8
-pep8
-coverage

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,6 @@
+pytest
+pytest-cov
+pytest-pep8
+pep8
+coverage
+coveralls

--- a/test/bats/pep8.bats
+++ b/test/bats/pep8.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 @test "PEP8 tests for interface code" {
+	skip "Moved to tox"
 	run pep8 scripts/pontoon*
 	[ "$status" = 0 ]
 }

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[pep8]
+ignore = E402
+[testenv]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+deps = -rrequirements.txt
+	   -rtest-requirements.txt
+commands = bats --tap test/bats
+           py.test --pep8 pontoon
+           py.test --cov=pontoon
+		   pep8 scripts/
+           coverage report -m
+           coveralls
+[pytest]
+pep8ignore = E402
+addopts = --ignore=venv
+		  -vv

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,19 @@
+[tox]
+envlist = py26, py27, py33, py34, pypy, pypy3
 [pep8]
 ignore = E402
 [testenv]
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps = -rrequirements.txt
 	   -rtest-requirements.txt
 commands = bats --tap test/bats
            py.test --pep8 pontoon
            py.test --cov=pontoon
 		   pep8 scripts/
-           coverage report -m
+[testenv:coveralls]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+commands = coverage report -m
            coveralls
+
 [pytest]
 pep8ignore = E402
 addopts = --ignore=venv


### PR DESCRIPTION
Use [Tox](https://tox.readthedocs.org) for a more consistent test environment, and fix some PEP errors.

Removes Python 3.2 testing since there appears to be some sort of compatibility issues with tox.

Added tests for Python 3.4, and Pypy 3.