### PR TITLE
Windows CI via Appveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 A Python CLI (and library) for [Digital Ocean](https://digitalocean.com).
 
 [![Coverage Status](https://coveralls.io/repos/duggan/pontoon/badge.png?branch=master)](https://coveralls.io/r/duggan/pontoon?branch=master)
-[![Build Status](https://travis-ci.org/duggan/pontoon.png?branch=master)](https://travis-ci.org/duggan/pontoon)
+ Linux: {[![Build Status on Linux](https://travis-ci.org/duggan/pontoon.png?branch=master)](https://travis-ci.org/duggan/pontoon)}
+ Windows: {[![Build status on Windows](https://ci.appveyor.com/api/projects/status/fj67qt2abc95i9ay?svg=true)](https://ci.appveyor.com/project/bendtherules/pontoon)}
+
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Python CLI (and library) for [Digital Ocean](https://digitalocean.com).
 
 [![Coverage Status](https://coveralls.io/repos/duggan/pontoon/badge.png?branch=master)](https://coveralls.io/r/duggan/pontoon?branch=master)
  Linux: {[![Build Status on Linux](https://travis-ci.org/duggan/pontoon.png?branch=master)](https://travis-ci.org/duggan/pontoon)}
- Windows: {[![Build status on Windows](https://ci.appveyor.com/api/projects/status/fj67qt2abc95i9ay?svg=true)](https://ci.appveyor.com/project/bendtherules/pontoon)}
+ Windows: {[![Build status on Windows](https://ci.appveyor.com/api/projects/status/rljdp3isvaj2pl3q?svg=true)](https://ci.appveyor.com/project/duggan/pontoon)}
 
 
 ## Introduction

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 A Python CLI (and library) for [Digital Ocean](https://digitalocean.com).
 
-[![Coverage Status](https://coveralls.io/repos/duggan/pontoon/badge.png?branch=master)](https://coveralls.io/r/duggan/pontoon?branch=master)
- Linux: {[![Build Status on Linux](https://travis-ci.org/duggan/pontoon.png?branch=master)](https://travis-ci.org/duggan/pontoon)}
- Windows: {[![Build status on Windows](https://ci.appveyor.com/api/projects/status/rljdp3isvaj2pl3q?svg=true)](https://ci.appveyor.com/project/duggan/pontoon)}
-
+| Linux CI | Windows CI | Code Coverage | Docs |
+|:--------:|:----------:|:-------------:|:----:|
+| [![Build Status on Linux](https://travis-ci.org/duggan/pontoon.png?branch=master)](https://travis-ci.org/duggan/pontoon) | [![Build status on Windows](https://ci.appveyor.com/api/projects/status/rljdp3isvaj2pl3q?svg=true)](https://ci.appveyor.com/project/duggan/pontoon) | [![Coverage Status](https://coveralls.io/repos/duggan/pontoon/badge.png?branch=master)](https://coveralls.io/r/duggan/pontoon?branch=master) | [![Documentation Status](https://readthedocs.org/projects/pontoon/badge/?version=latest)](http://pontoon.readthedocs.org/en/latest/?badge=latest)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -184,9 +184,3 @@ This functionality is implemented by the `@debug` decorator, the code for which 
 Set the `MOCK` environment variable (to anything) to return mock request data instead of querying Digital Ocean.
 
 This is implemented soley for end-to-end testing of the CLI, but you may find it useful in some other scenarios.
-
-## Addendum
-
-### Windows support
-
-Pontoon's lack of Windows support is a bug, not a feature. If you need pontoon on Windows, the best way to help get it there is with a pull request.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,6 +60,10 @@ install:
   - ECHO "Filesystem root:"
   - ps: "ls \"C:/\""
 
+  # Workaround for failing builds on Python 3.x 64 bit (taken from SpiceyPy project)
+  - IF "%PYTHON_ARCH%"=="32" (call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86) ELSE (ECHO "probably a 64bit build")
+  - IF "%PYTHON_ARCH%"=="64" (call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64) ELSE (ECHO "probably a 32bit build")
+
   # Install Python (from the official .msi of http://python.org) and pip when
   # not already installed.
   - ps: if (-not(Test-Path($env:PYTHON))) { & appveyor\install.ps1 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,102 @@
+environment:
+
+  global:
+
+    MOCK: "1"
+    PIP_DOWNLOAD_CACHE : "C\\PIP_DOWNLOAD_CACHE"
+
+  matrix:
+
+    # Pre-installed Python versions, which Appveyor may upgrade to
+    # a later point release.
+    # See: http://www.appveyor.com/docs/installed-software#python
+
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x" # currently 2.7.9
+      PYTHON_ARCH: "32"
+      TOXENV: "py27,lib,coverage"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x" # currently 2.7.9
+      PYTHON_ARCH: "64"
+      TOXENV: "py27,lib,coverage"
+
+    - PYTHON: "C:\\Python33"
+      PYTHON_VERSION: "3.3.x" # currently 3.3.5
+      PYTHON_ARCH: "32"
+      TOXENV: "py33,lib,coverage"
+
+    - PYTHON: "C:\\Python33-x64"
+      PYTHON_VERSION: "3.3.x" # currently 3.3.5
+      PYTHON_ARCH: "64"
+      TOXENV: "py33,lib,coverage"
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.x" # currently 3.4.3
+      PYTHON_ARCH: "32"
+      TOXENV: "py34,lib,coverage"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x" # currently 3.4.3
+      PYTHON_ARCH: "64"
+      TOXENV: "py34,lib,coverage"
+
+    # Python versions not pre-installed
+
+    # Python 2.6.6 is the latest Python 2.6 with a Windows installer
+    # See: https://github.com/ogrisel/python-appveyor-demo/issues/10
+
+    - PYTHON: "C:\\Python266"
+      PYTHON_VERSION: "2.6.6"
+      PYTHON_ARCH: "32"
+      TOXENV: "py26,lib,coverage"
+
+    - PYTHON: "C:\\Python266-x64"
+      PYTHON_VERSION: "2.6.6"
+      PYTHON_ARCH: "64"
+      TOXENV: "py26,lib,coverage"
+
+install:
+  - ECHO "Filesystem root:"
+  - ps: "ls \"C:/\""
+
+  # Install Python (from the official .msi of http://python.org) and pip when
+  # not already installed.
+  - ps: if (-not(Test-Path($env:PYTHON))) { & appveyor\install.ps1 }
+
+  # Prepend newly installed Python to the PATH of this build (this cannot be
+  # done from inside the powershell script as it would require to restart
+  # the parent CMD process).
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+  # Check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  # Upgrade to the latest version of pip to avoid it displaying warnings
+  # about it being out of date.
+  - "pip install --disable-pip-version-check --user --upgrade pip"
+
+  # Install the build dependencies of the project.
+  - "pip install tox"
+
+build: off
+
+test_script:
+  # Run the project tests
+  - "tox"
+
+after_test:
+  # If tests are successful, create binary packages for the project.
+  - "pip install wheel"
+  - "python setup.py bdist_wheel"
+  - "python setup.py bdist_wininst"
+  - "python setup.py bdist_msi"
+  - ps: "ls dist"
+
+artifacts:
+  # Archive the generated packages in the ci.appveyor.com build report.
+  - path: dist\*
+
+#on_success:
+#  - TODO: upload the content of dist/*.whl to a public wheelhouse

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -1,0 +1,229 @@
+# Sample script to install Python and pip under Windows
+# Authors: Olivier Grisel, Jonathan Helmus, Kyle Kastner, and Alex Willmer
+# License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+
+$MINICONDA_URL = "http://repo.continuum.io/miniconda/"
+$BASE_URL = "https://www.python.org/ftp/python/"
+$GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
+$GET_PIP_PATH = "C:\get-pip.py"
+
+$PYTHON_PRERELEASE_REGEX = @"
+(?x)
+(?<major>\d+)
+\.
+(?<minor>\d+)
+\.
+(?<micro>\d+)
+(?<prerelease>[a-z]{1,2}\d+)
+"@
+
+
+function Download ($filename, $url) {
+    $webclient = New-Object System.Net.WebClient
+
+    $basedir = $pwd.Path + "\"
+    $filepath = $basedir + $filename
+    if (Test-Path $filename) {
+        Write-Host "Reusing" $filepath
+        return $filepath
+    }
+
+    # Download and retry up to 3 times in case of network transient errors.
+    Write-Host "Downloading" $filename "from" $url
+    $retry_attempts = 2
+    for ($i = 0; $i -lt $retry_attempts; $i++) {
+        try {
+            $webclient.DownloadFile($url, $filepath)
+            break
+        }
+        Catch [Exception]{
+            Start-Sleep 1
+        }
+    }
+    if (Test-Path $filepath) {
+        Write-Host "File saved at" $filepath
+    } else {
+        # Retry once to get the error message if any at the last try
+        $webclient.DownloadFile($url, $filepath)
+    }
+    return $filepath
+}
+
+
+function ParsePythonVersion ($python_version) {
+    if ($python_version -match $PYTHON_PRERELEASE_REGEX) {
+        return ([int]$matches.major, [int]$matches.minor, [int]$matches.micro,
+                $matches.prerelease)
+    }
+    $version_obj = [version]$python_version
+    return ($version_obj.major, $version_obj.minor, $version_obj.build, "")
+}
+
+
+function DownloadPython ($python_version, $platform_suffix) {
+    $major, $minor, $micro, $prerelease = ParsePythonVersion $python_version
+
+    if (($major -le 2 -and $micro -eq 0) `
+        -or ($major -eq 3 -and $minor -le 2 -and $micro -eq 0) `
+        ) {
+        $dir = "$major.$minor"
+        $python_version = "$major.$minor$prerelease"
+    } else {
+        $dir = "$major.$minor.$micro"
+    }
+
+    if ($prerelease) {
+        if (($major -le 2) `
+            -or ($major -eq 3 -and $minor -eq 1) `
+            -or ($major -eq 3 -and $minor -eq 2) `
+            -or ($major -eq 3 -and $minor -eq 3) `
+            ) {
+            $dir = "$dir/prev"
+        }
+    }
+
+    if (($major -le 2) -or ($major -le 3 -and $minor -le 4)) {
+        $ext = "msi"
+        if ($platform_suffix) {
+            $platform_suffix = ".$platform_suffix"
+        }
+    } else {
+        $ext = "exe"
+        if ($platform_suffix) {
+            $platform_suffix = "-$platform_suffix"
+        }
+    }
+
+    $filename = "python-$python_version$platform_suffix.$ext"
+    $url = "$BASE_URL$dir/$filename"
+    $filepath = Download $filename $url
+    return $filepath
+}
+
+
+function InstallPython ($python_version, $architecture, $python_home) {
+    Write-Host "Installing Python" $python_version "for" $architecture "bit architecture to" $python_home
+    if (Test-Path $python_home) {
+        Write-Host $python_home "already exists, skipping."
+        return $false
+    }
+    if ($architecture -eq "32") {
+        $platform_suffix = ""
+    } else {
+        $platform_suffix = "amd64"
+    }
+    $installer_path = DownloadPython $python_version $platform_suffix
+    $installer_ext = [System.IO.Path]::GetExtension($installer_path)
+    Write-Host "Installing $installer_path to $python_home"
+    $install_log = $python_home + ".log"
+    if ($installer_ext -eq '.msi') {
+        InstallPythonMSI $installer_path $python_home $install_log
+    } else {
+        InstallPythonEXE $installer_path $python_home $install_log
+    }
+    if (Test-Path $python_home) {
+        Write-Host "Python $python_version ($architecture) installation complete"
+    } else {
+        Write-Host "Failed to install Python in $python_home"
+        Get-Content -Path $install_log
+        Exit 1
+    }
+}
+
+
+function InstallPythonEXE ($exepath, $python_home, $install_log) {
+    $install_args = "/quiet InstallAllUsers=1 TargetDir=$python_home"
+    RunCommand $exepath $install_args
+}
+
+
+function InstallPythonMSI ($msipath, $python_home, $install_log) {
+    $install_args = "/qn /log $install_log /i $msipath TARGETDIR=$python_home"
+    $uninstall_args = "/qn /x $msipath"
+    RunCommand "msiexec.exe" $install_args
+    if (-not(Test-Path $python_home)) {
+        Write-Host "Python seems to be installed else-where, reinstalling."
+        RunCommand "msiexec.exe" $uninstall_args
+        RunCommand "msiexec.exe" $install_args
+    }
+}
+
+function RunCommand ($command, $command_args) {
+    Write-Host $command $command_args
+    Start-Process -FilePath $command -ArgumentList $command_args -Wait -Passthru
+}
+
+
+function InstallPip ($python_home) {
+    $pip_path = $python_home + "\Scripts\pip.exe"
+    $python_path = $python_home + "\python.exe"
+    if (-not(Test-Path $pip_path)) {
+        Write-Host "Installing pip..."
+        $webclient = New-Object System.Net.WebClient
+        $webclient.DownloadFile($GET_PIP_URL, $GET_PIP_PATH)
+        Write-Host "Executing:" $python_path $GET_PIP_PATH
+        & $python_path $GET_PIP_PATH
+    } else {
+        Write-Host "pip already installed."
+    }
+}
+
+
+function DownloadMiniconda ($python_version, $platform_suffix) {
+    if ($python_version -eq "3.4") {
+        $filename = "Miniconda3-3.5.5-Windows-" + $platform_suffix + ".exe"
+    } else {
+        $filename = "Miniconda-3.5.5-Windows-" + $platform_suffix + ".exe"
+    }
+    $url = $MINICONDA_URL + $filename
+    $filepath = Download $filename $url
+    return $filepath
+}
+
+
+function InstallMiniconda ($python_version, $architecture, $python_home) {
+    Write-Host "Installing Python" $python_version "for" $architecture "bit architecture to" $python_home
+    if (Test-Path $python_home) {
+        Write-Host $python_home "already exists, skipping."
+        return $false
+    }
+    if ($architecture -eq "32") {
+        $platform_suffix = "x86"
+    } else {
+        $platform_suffix = "x86_64"
+    }
+    $filepath = DownloadMiniconda $python_version $platform_suffix
+    Write-Host "Installing" $filepath "to" $python_home
+    $install_log = $python_home + ".log"
+    $args = "/S /D=$python_home"
+    Write-Host $filepath $args
+    Start-Process -FilePath $filepath -ArgumentList $args -Wait -Passthru
+    if (Test-Path $python_home) {
+        Write-Host "Python $python_version ($architecture) installation complete"
+    } else {
+        Write-Host "Failed to install Python in $python_home"
+        Get-Content -Path $install_log
+        Exit 1
+    }
+}
+
+
+function InstallMinicondaPip ($python_home) {
+    $pip_path = $python_home + "\Scripts\pip.exe"
+    $conda_path = $python_home + "\Scripts\conda.exe"
+    if (-not(Test-Path $pip_path)) {
+        Write-Host "Installing pip..."
+        $args = "install --yes pip"
+        Write-Host $conda_path $args
+        Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
+    } else {
+        Write-Host "pip already installed."
+    }
+}
+
+function main () {
+    InstallPython $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON
+    InstallPip $env:PYTHON
+}
+
+main

--- a/pontoon/ui.py
+++ b/pontoon/ui.py
@@ -2,7 +2,12 @@
 
 from __future__ import print_function
 
-import readline
+# Windows / missing-readline compat
+try:
+    import readline
+except ImportError:
+    pass
+
 import textwrap
 from os.path import (isfile, expanduser,
                      basename, splitext, join)


### PR DESCRIPTION
Adds support for Windows CI testing via Appveyor thanks to @bendtherules.

Squashes and tidies up commits from #33, as well as making `readline` a progressive enhancement.

Also contains a fix for the 64 bit Python 3.x builds.