### PR TITLE
Fix typos in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ BUGFIXES:
 
 FEATURES:
 
-   * **Pass commands to Droplet** Can pass shell commands to a Droplet, e.g,
+   * **Pass commands to Droplet** Can pass shell commands to a Droplet, e.g.,
 	 `pontoon droplet ssh example.com "ls /"`
 
 ## 0.2.1 (November 6, 2015)

--- a/README.md
+++ b/README.md
@@ -175,4 +175,4 @@ This functionality is implemented by the `@debug` decorator, the code for which 
 
 Set the `MOCK` environment variable (to anything) to return mock request data instead of querying Digital Ocean.
 
-This is implemented soley for end-to-end testing of the CLI, but you may find it useful in some other scenarios.
+This is implemented solely for end-to-end testing of the CLI, but you may find it useful in some other scenarios.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -209,7 +209,7 @@ Mocking
 Set the ``MOCK`` environment variable (to anything) to return mock
 request data instead of querying Digital Ocean.
 
-This is implemented soley for end-to-end testing of the CLI, but you may
+This is implemented solely for end-to-end testing of the CLI, but you may
 find it useful in some other scenarios.
 
 .. |Build Status on Linux| image:: https://travis-ci.org/duggan/pontoon.png?branch=master

--- a/docs/dev/testing.rst
+++ b/docs/dev/testing.rst
@@ -81,7 +81,7 @@ Mocking
 Set the ``MOCK`` environment variable (to anything) to return mock
 request data instead of querying Digital Ocean.
 
-This is implemented soley for end-to-end testing of the CLI, but you may
+This is implemented solely for end-to-end testing of the CLI, but you may
 find it useful in some other scenarios.
 
 Addendum

--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -9,4 +9,4 @@ Via pip:
 
 Pontoon works with Pythons 2.6 through 3.5, and should work on any Linux/BSD with Python support.
 
-It's also possible to use pontoon on Windows, though portions of the configuarion command (which make use of Linux CLI tools like OpenSSH) do not work.
+It's also possible to use pontoon on Windows, though portions of the configuration command (which make use of Linux CLI tools like OpenSSH) do not work.

--- a/docs/user/reference.rst
+++ b/docs/user/reference.rst
@@ -340,7 +340,7 @@ Public base images made available by Digital Ocean.
 
 .. option:: pontoon image oses
 
-   Retrive a list of Operating Systems for which there are base images.
+   Retrieve a list of Operating Systems for which there are base images.
 
 |
 
@@ -442,7 +442,7 @@ Manage SSH keys in your account.
 
 .. option:: pontoon sshkey show <name>
 
-   Retrive a public key by name.
+   Retrieve a public key by name.
 
 |
 


### PR DESCRIPTION
Found using [mwic](http://jwilk.net/software/mwic).