### PR TITLE
Don't use bare "except:"

### DIFF
--- a/pontoon/ui.py
+++ b/pontoon/ui.py
@@ -25,7 +25,7 @@ except ImportError:
 # Python 2/3 compatibility
 try:
     user_input = raw_input
-except:
+except NameError:
     user_input = input
 
 


### PR DESCRIPTION
The `except:` clause would catch all the exceptions, including `KeyboardInterrupt`.