### PR TITLE
Command: Minimize scope of catching KeyError

### DIFF
--- a/pontoon/command.py
+++ b/pontoon/command.py
@@ -24,9 +24,12 @@ class Command:
             command = override
 
         try:
-            return getattr(self, command)()
-        except (KeyboardInterrupt, EOFError):
-            return 0
+            method = getattr(self, command)
         except KeyError:
             ui.message("No command '%s'" % command)
+            return 1
+        try:
+            return method()
+        except (KeyboardInterrupt, EOFError):
+            return 0
         return 1


### PR DESCRIPTION
Limit the scope of catching `KeyError` in `Command.run()`, so that it doesn't say `No command` when the command actually exists but raises this exception.

This should help in debugging issue #51.