### PR TITLE
Include public key path during first configuration. Fixes #51

### DIFF
--- a/pontoon/cmd/pontoon_configure.py
+++ b/pontoon/cmd/pontoon_configure.py
@@ -65,7 +65,7 @@ class ConfigureCommand(Command):
                     config[key_name] = ui.ask("Path to SSH private key")
 
         else:
-            for key in ['private']:
+            for key in ['private', 'public']:
                 key_name = 'ssh_%s_key' % key
                 auth_key = ui.ask("Path to SSH %s key (default %s)" % (
                                   key, default[key_name]))


### PR DESCRIPTION
I think I was trying to be clever here and infer a key path from the private key name, but apparently never included the clever part! Asking for it is probably easier.