### PR TITLE
pontoon ssh: Don't require configured SSH key

### DIFF
--- a/pontoon/cmd/pontoon_droplet.py
+++ b/pontoon/cmd/pontoon_droplet.py
@@ -196,19 +196,21 @@ class DropletCommand(Command):
             auth_key = self.args['--key']
         else:
             auth_key = self.config.get('ssh_private_key')
-        auth_key = ui.full_path(auth_key)
+        if auth_key is not None:
+            auth_key = ui.full_path(auth_key)
 
         command = ""
         if self.args['<command>']:
             command = self.args['<command>']
 
         options = ['ssh',
-                   '-i', '%s' % auth_key,
                    '-o', 'StrictHostKeyChecking=no',
                    '-o', 'UserKnownHostsFile=/dev/null',
-                   '-o', 'LogLevel=error',
-                   '%s@%s' % (username, hostname),
-                   '%s' % command]
+                   '-o', 'LogLevel=error']
+        if auth_key is not None:
+            options += ['-i', '%s' % auth_key]
+        options += ['%s@%s' % (username, hostname),
+                    '%s' % command]
 
         return call(options)
 


### PR DESCRIPTION
Some people might not want to use public key authentication; or, like me, they have SSH already configured to use public key authentication and don't want to duplicate this configuration in their `~/.pontoon`.

This PR fixes:

    'NoneType' object has no attribute 'startswith'

when there was no `ssh_private_key` in `~/.pontoon` and the `--key` option was not used.