### PR TITLE
Fix listing images with no slugs

### DIFF
--- a/pontoon/cmd/pontoon_image.py
+++ b/pontoon/cmd/pontoon_image.py
@@ -55,11 +55,11 @@ class ImageCommand(Command):
             if self.args['--with-ids']:
                 name = s.name[:27] + "..." if len(s.name) > 30 else s.name
                 ui.message(" - %-10s %-10s %-35s %s" % (
-                           str(s.id) + ':', s.distribution, name, s.slug))
+                           str(s.id) + ':', s.distribution, name, s.slug or ''))
             else:
                 name = s.name[:37] + "..." if len(s.name) > 40 else s.name
                 ui.message(" - %-10s %-45s %s" % (
-                           s.distribution, name, s.slug))
+                           s.distribution, name, s.slug or ''))
         return 0
 
     def show(self):


### PR DESCRIPTION
For image with no slug, omit the slug field completely, instead of printing literally `None`.